### PR TITLE
No longer pass token as curl header

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@main # TODO: use @v1 once availible
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        uses: keep-network/load-env-variables@v1
         with:
           environment: 'ropsten'
           ref: 'master'

--- a/README.md
+++ b/README.md
@@ -19,14 +19,9 @@ The action supports following input parameters:
 
 ```yaml
       - uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           environment: 'ropsten'
 ```
-NOTE: As action downloads data from private `keep-network/ci` repository,
-authentication is required - token allowing for access to the repository must be
-passed in `CI_GITHUB_TOKEN` environment variable.
 
 ## Configuration of the input file
 
@@ -51,7 +46,7 @@ sensitive data, use GitHub's _Secrets_ functionality.
 ## Using imported variables
 
 Imported variables can be accessed from the `env` context in the job in which
-action was used. To use the variables in different job, you must invoke the
+action was used. To use the variables in a different job, you must invoke the
 `load-env-variables` action there as well .
 
 Example:
@@ -65,8 +60,6 @@ jobs:
     runs-on: ubuntu-latest
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           filename: 'ropsten'
       - name: Use loaded variables

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Download configuration file (${{ inputs.environment }}.env)
       run: |
         echo "-- Running curl.sh ..." 
-        ${{ github.action_path }}/curl.sh ${{ inputs.environment }}.env ${{ inputs.ref }} ${{ env.CI_GITHUB_TOKEN }}
+        ${{ github.action_path }}/curl.sh ${{ inputs.environment }}.env ${{ inputs.ref }}
       shell: bash
     - name: Load variables
       run: |

--- a/curl.sh
+++ b/curl.sh
@@ -7,7 +7,6 @@ if ! [ -x "$(command -v curl)" ]; then echo "curl is not installed"; exit 1; fi
 echo "-- Downloading config file: $1 ..."
 set -x
 curl \
-  --header "Authorization: token $3" \
   --header "Accept: application/vnd.github.v3.raw" \
   --output "$1" \
   --show-error \


### PR DESCRIPTION
The `keep-network/ci` repository storing the config files used by the
`load-env-variables` action is no longer private. This means that we
no longer need to authenticate curl with the token allowing access to
the repository.