### PR TITLE
Migrate from `master` to `main` branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         uses: keep-network/load-env-variables@v1
         with:
           environment: 'ropsten'
-          ref: 'master'
+          ref: 'main'
 
       - name: Use imported variables
         run: |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The action supports following input parameters:
 
 - `environment` (required)
 
-- `ref` (optional, default: `master`)
+- `ref` (optional, default: `main`)
 
 ## Action usage
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   ref:
     description: Ref of the config file to be used
     required: false
-    default: master
+    default: main
 runs:
   using: composite
   steps:


### PR DESCRIPTION
Use of the `master` and `slave` terms in the computer industry is
widespread, but has been recently discouraged, as it was brought to
attention that the terms may be considered offensive.
GitHub has already moved their default repositories from the `master`
to `main` in many places. We're planning to do the same for our
repositories, this however requires some changes in the code.
The `load-env-variables` repository was already using `main` branch,
but referenced 'master' in coule of places in the code. This commit
modifies those mentions (corresponding changes has been also
introduced in other repositories).

Refs:
https://github.com/keep-network/keep-core/pull/2521
https://github.com/keep-network/keep-ecdsa/pull/845
https://github.com/keep-network/tbtc/pull/810
https://github.com/keep-network/tbtc-dapp/pull/399
https://github.com/keep-network/tbtc.js/pull/126
https://github.com/keep-network/keep-common/pull/79
https://github.com/keep-network/sortition-pools/pull/113
https://github.com/keep-network/local-setup/pull/97
https://github.com/keep-network/ci/pull/8
https://github.com/keep-network/run-workflow/pull/3
https://github.com/keep-network/notify-workflow-completed/pull/3